### PR TITLE
fix: updated extension yaml files to work with the latest cadvisor v0.49.1

### DIFF
--- a/extension/docker-compose-browser.yaml
+++ b/extension/docker-compose-browser.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # The extension's UI/Backend
   docketeer:
@@ -30,9 +28,8 @@ services:
       - memcached
 
   cadvisor:
-    # Must use cadvisor v0.47.1 instead of latest, latest does not work for macOS
-    # The docketeer image uploaded is on gcr.io/cadvisor/cadvisor:v0.47.1
-    image: gcr.io/cadvisor/cadvisor:v0.47.1
+    # The docketeer image uploaded is on gcr.io/cadvisor/cadvisor:v0.49.1
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
     container_name: docketeer-ext-cadvisor
     expose:
       - 8080
@@ -40,11 +37,18 @@ services:
       - 49158:8080
     volumes:
       # Applies the bind mounts in ro (read only) and rw (read write) to be able to scrape containers
-      - /:/rootfs:ro
-      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - /etc/machine-id:/etc/machine-id:ro
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id:ro
+      - /:/rootfs:ro
+      - /dev/disk/:/dev/disk:ro
+    privileged: true
+    restart: unless-stopped
+    devices:
+      - /dev/kmsg
 
   # Collects additional metrics that are then sent to prometheus
   node-exporter:

--- a/extension/docker-compose-dev.yaml
+++ b/extension/docker-compose-dev.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # The extension's UI/Backend
   docketeer:
@@ -21,9 +19,8 @@ services:
 
 
   cadvisor:
-    # Must use cadvisor v0.47.1 instead of latest, latest does not work for macOS
-    # The docketeer image uploaded is on gcr.io/cadvisor/cadvisor:v0.47.1
-    image: gcr.io/cadvisor/cadvisor:v0.47.1
+    # The docketeer image uploaded is on gcr.io/cadvisor/cadvisor:v0.49.1
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
     container_name: docketeer-ext-cadvisor
     expose:
       - 8080
@@ -31,11 +28,18 @@ services:
       - 49158:8080
     volumes:
       # Applies the bind mounts in ro (read only) and rw (read write) to be able to scrape containers
-      - /:/rootfs:ro
-      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - /etc/machine-id:/etc/machine-id:ro
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id:ro
+      - /:/rootfs:ro
+      - /dev/disk/:/dev/disk:ro
+    privileged: true
+    restart: unless-stopped
+    devices:
+      - /dev/kmsg
 
   # Collects additional metrics that are then sent to prometheus 
   node-exporter:

--- a/extension/docker-compose-prod.yaml
+++ b/extension/docker-compose-prod.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # The extension's UI/Backend
   docketeer:
@@ -18,19 +16,26 @@ services:
       - memcached
 
   cadvisor:
-    # Must use cadvisor v0.47.1 instead of latest, latest does not work for macOS
-    # The docketeer image uploaded is on gcr.io/cadvisor/cadvisor:v0.47.1
-    image: gcr.io/cadvisor/cadvisor:v0.47.1
+    # The docketeer image uploaded is on gcr.io/cadvisor/cadvisor:v0.49.1
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
     container_name: docketeer-ext-cadvisor
     expose:
       - 8080
     volumes:
       # Applies the bind mounts in ro (read only) and rw (read write) to be able to scrape containers
-      - /:/rootfs:ro
-      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - /etc/machine-id:/etc/machine-id:ro
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id:ro
+      - /:/rootfs:ro
+      - /dev/disk/:/dev/disk:ro
+    privileged: true
+    restart: unless-stopped
+    devices:
+      - /dev/kmsg
+      
   # Collects additional metrics that are then sent to prometheus 
   node-exporter:
     image: prom/node-exporter:v1.6.1


### PR DESCRIPTION
<!---
☝️ Prefix your PR title with `fix:`, `feat:`, `docs:`, or other according to the Conventional Commits spec:
https://conventionalcommits.org

👉 Please make sure to follow our Contributing guidelines:
https://github.com/open-source-labs/.github/blob/main/docs/CONTRIBUTING.md
-->

## 🔗 Linked issue

 <!-- Resolves #123 -->
Sorry, I couldn't find the issues list but I see the comments about being stuck on cadvisor v0.47.1 in the code.

## Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Updated extension yaml files to work with latest cadvisor v0.49.1, gcr.io/cadvisor/cadvisor:v0.49.1
## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've followed the [Contributing guidelines](https://github.com/open-source-labs/.github/blob/main/docs/CONTRIBUTING.md)

- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've linked an open issue
- [ ] I've added tests that fail without this PR but pass with it
- [x] I've linted and tested my code
- [ ] I've updated documentation (if appropriate)
